### PR TITLE
Make library compatible with `deno bundle`

### DIFF
--- a/mod.js
+++ b/mod.js
@@ -234,7 +234,7 @@ function nodejsMathRandomBytes(byteLength) {
 }
 const nodejsRandomBytes = await (async () => {
     try {
-        return (await import('crypto')).randomBytes;
+        return (await import('node:crypto')).randomBytes;
     }
     catch {
         return nodejsMathRandomBytes;


### PR DESCRIPTION
I tried to bundle this library in one of my own libraries using `deno bundle`, but it didn't work. It threw the following error:

```
⚠️ deno bundle is experimental and subject to changes
error: Do not know how to load path: deno:https://jsr.io/@lucsoft/web-bson/0.4.0/crypto
    at deno:https://jsr.io/@lucsoft/web-bson/0.4.0/mod.js:222:25
error: bundling failed
```

This has to do with it trying to load `crypto` (which I assume is the Node.JS version), which should be noted as `node:crypto`